### PR TITLE
Untitled

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+*.tmproj
+.DS_Store

--- a/Makefile
+++ b/Makefile
@@ -2,4 +2,13 @@
 test:
 	@./support/expresso/bin/expresso -I support
 
+test-resource:
+	@./support/expresso/bin/expresso -I support test/resource.test.js
+
+test-singular:
+	@./support/expresso/bin/expresso -I support test/singular.test.js
+
+test-extra-routes:
+	@./support/expresso/bin/expresso -I support test/extra-routes.test.js
+
 .PHONY: test

--- a/Readme.md
+++ b/Readme.md
@@ -67,7 +67,6 @@ Actions are then mapped as follows (by default):
     PUT     /forums/:id       ->  update
     DELETE  /forums/:id       ->  destroy
 
-
 Specify a top-level resource by omitting the resource name:
 
     var express = require('express')
@@ -86,6 +85,63 @@ Top-level actions are then mapped as follows (by default):
     PUT     /:id              ->  update
     DELETE  /:id              ->  destroy
 
+
+The `app.singular_resource()` method will create and return a new `Resource` that can be accessed without using an `id` (such as the profile for the current user):
+
+    var express = require('express')
+      , Resource = require('express-resource')
+      , app = express.createServer();
+
+    app.singular_resource('profile', require('./profile'));
+
+Actions are then mapped as follows (by default):
+
+    GET     /profile/new       ->  new
+    POST    /profile           ->  create
+    GET     /profile           ->  show
+    GET     /profile/edit      ->  edit
+    PUT     /profile           ->  update
+    DELETE  /profile           ->  destroy
+
+Note that there is no `index` action for a singular resource.
+
+The top-level resource may be singular.
+
+The `Resource.prototype.member()` and `Resource.prototype.collection()` methods can be used to add extra routes to a `Resource`. A member route identifies the resource by its `id`, a collection route doesn't. Calls to these members can be chained. For instance,
+
+    var ret = app.resource('forums', require('./forums'));
+
+    ret.member('search', 'post').member('display', 'get');
+
+would map the following actions:
+
+    GET     /forums/:id/display  ->  display
+    POST    /forums/:id/search   ->  search
+
+If you prefer, the method `Resource.prototype.members()` can be passed an object, whose keys are the action names and whose values are the HTTP verbs. The above example could have been achieved like this:
+
+    ret.members({search:'post', display: 'get' });
+
+Similarly,
+
+    ret.collection('map', 'post').collection('sequence', 'get');
+
+or
+
+    ret.collections({map:'post', sequence: 'get' });
+
+would provide
+
+    GET     /forums/sequence  ->  sequence
+    POST    /forums/map       ->  map
+
+__NOTE:__ The extra routes are added after the standard ones, which may lead to clashes when collection routes use the `GET` verb. For instance, after adding the collections above, the request `GET /forums/sequence` would still resolve to the `show` action, with `sequence` being treated as the `id`. To avoid such clashes, you can use the _id_ option with a regex to apply restrictions to the form of `id`. Regex metacharacters must be escaped. For instance,
+
+    exports.id = 'id\(\\d\+\)';
+
+will ensure that `id`s consist entirely of digits, so `/forums/sequence` will invoke the `sequence` action, while `/forums/5` calls `display`, as usual.
+
+If you find you are adding many extra routes to a resource, you should suspect that something is wrong with your analysis of resources.
 
 __NOTE:__ this functionality will surely grow with time, and as data store clients evolve we can provide close integration.
 

--- a/index.js
+++ b/index.js
@@ -18,16 +18,17 @@ var express = require('express');
  * @param {String} name
  * @param {Object} actions
  * @param {Server} app
+ * @param {Boolean} singular
  * @api private
  */
 
-var Resource = module.exports = function Resource(name, actions, app) {
+var Resource = module.exports = function Resource(name, actions, app, singular) {
   this.name = name;
   this.app = app;
   this.actions = actions
   this.id = actions.id || 'id';
   for (var key in actions) {
-    this.defineAction(key, actions[key]);
+    this.defineAction(key, actions[key], singular);
   }
 };
 
@@ -36,53 +37,64 @@ var Resource = module.exports = function Resource(name, actions, app) {
  *
  * @param {String} key
  * @param {Function} fn
+ * @param {Boolean} singular
  * @api public
  */
 
-Resource.prototype.defineAction = function(key, fn){
+Resource.prototype.defineAction = function(key, fn, singular){
   var app = this.app
     , id = this.id
     , name = '/' + (this.name || '')
-    , path = this.name ? name + '/' : '/';
-
-  switch (key) {
-    case 'index':
+    , slash = (this.name? '/' : '')
+    , id_segment = singular? '': slash + ':' + id;
+    
+    if (!singular && key == 'index') {
       app.get(name, fn);
-      break;
-    case 'new':
-      app.get(path + 'new', fn);
-      break;
-    case 'create':
-      app.post(name, fn);
-      break;
-    case 'show':
-      app.get(path + ':' + id, fn);
-      break;
-    case 'edit':
-      app.get(path + ':' + id + '/edit', fn);
-      break;
-    case 'update':
-      app.put(path + ':' + id, fn);
-      break;
-    case 'destroy':
-      app.del(path + ':' + id, fn);
-      break;
+    }
+    else {
+      switch (key) {
+        case 'new':
+          app.get(name + slash + 'new', fn);
+          break;
+        case 'create':
+          app.post(name, fn);
+          break;
+        case 'show':
+          app.get(name + id_segment, fn);
+          break;
+        case 'edit':
+          app.get(name + id_segment + '/edit', fn);
+          break;
+        case 'update':
+          app.put(name + id_segment, fn);
+          break;
+        case 'destroy':
+          app.del(name + id_segment, fn);
+          break;
+      }
   }
 };
-
 /**
  * Define a resource with the given `name` and `actions`.
  *
  * @param {String|Object} name or actions
  * @param {Object} actions
+ * @param {Boolan} singular
  * @return {Resource}
  * @api public
  */
+ 
+var define_resource = function(singular) {
+  return function(name, actions){
+    if ('object' == typeof name) { actions = name; name = null; }
+    this.resources = this.resources || {};
+    var res = this.resources[name] = new Resource(name, actions, this, singular);
+    return res;
+  };
+}
 
 express.HTTPServer.prototype.resource =
-express.HTTPSServer.prototype.resource = function(name, actions){
-  if ('object' == typeof name) actions = name, name = null;
-  this.resources = this.resources || {};
-  var res = this.resources[name] = new Resource(name, actions, this);
-  return res;
-};
+express.HTTPSServer.prototype.resource = define_resource(false);
+
+express.HTTPServer.prototype.singular_resource =
+express.HTTPSServer.prototype.singular_resource = define_resource(true);

--- a/test/extra-routes.test.js
+++ b/test/extra-routes.test.js
@@ -1,0 +1,94 @@
+
+/**
+ * Module dependencies.
+ */
+var assert = require('assert')
+  , express = require('express')
+  , Resource = require('../');
+
+module.exports = {
+  'test Resource.prototype.member() chain': function() {
+    var app = express.createServer();
+
+
+    var ret = app.resource('forums', require('./fixtures/forumplus'));
+
+    assert.ok(ret instanceof Resource);
+    ret.member('search', 'post').member('display', 'get');
+
+    
+    assert.response(app,
+      { url: '/forums/5/search', method: 'POST' },
+      { body: 'search forum 5' });
+
+    assert.response(app,
+      { url: '/forums/5/display' },
+      { body: 'display forum 5' });
+
+  },
+
+  'test Resource.prototype.members()': function() {
+    var app = express.createServer();
+
+
+    var ret = app.resource('forums', require('./fixtures/forumplus'));
+
+    assert.ok(ret instanceof Resource);
+    ret.members({search:'post', display: 'get' });
+
+    
+    assert.response(app,
+      { url: '/forums/5/search', method: 'POST' },
+      { body: 'search forum 5' });
+
+    assert.response(app,
+      { url: '/forums/5/display' },
+      { body: 'display forum 5' });
+
+  },
+
+  'test Resource.prototype.collection() chain': function() {
+    var app = express.createServer();
+
+
+    var ret = app.resource('forums', require('./fixtures/forumplus'));
+
+    assert.ok(ret instanceof Resource);
+    ret.collection('map', 'post').collection('sequence', 'get');
+
+    
+    assert.response(app,
+      { url: '/forums/map', method: 'POST' },
+      { body: 'map forums' });
+
+    assert.response(app,
+      { url: '/forums/sequence' },
+      { body: 'sequence forums' });
+
+  },
+
+  'test Resource.prototype.collections()': function() {
+    var app = express.createServer();
+
+
+    var ret = app.resource('forums', require('./fixtures/forumplus'));
+
+    assert.ok(ret instanceof Resource);
+    ret.collections({map:'post', sequence: 'get' });
+
+    
+    assert.response(app,
+      { url: '/forums/map', method: 'POST' },
+      { body: 'map forums' });
+
+    assert.response(app,
+      { url: '/forums/sequence' },
+      { body: 'sequence forums' });
+
+    assert.response(app,
+      { url: '/forums/5' },
+      { body: 'show forum 5' });
+
+  }
+
+};

--- a/test/fixtures/forumplus.js
+++ b/test/fixtures/forumplus.js
@@ -1,3 +1,4 @@
+exports.id = 'id\(\\d\+\)';
 
 exports.index = function(req, res){
   res.send('forum index');
@@ -25,5 +26,21 @@ exports.update = function(req, res){
 
 exports.destroy = function(req, res){
   res.send('destroy forum ' + req.params.id);
+};
+
+exports.search = function(req, res) {
+  res.send('search forum ' + req.params.id);
+};
+
+exports.display = function(req, res) {
+  res.send('display forum ' + req.params.id);
+};
+
+exports.map = function(req, res) {
+	res.send('map forums');
+};
+
+exports.sequence = function(req, res) {
+	res.send('sequence forums');
 };
 

--- a/test/fixtures/profile.js
+++ b/test/fixtures/profile.js
@@ -1,0 +1,24 @@
+
+exports.new = function(req, res){
+  res.send('new profile');
+};
+
+exports.create = function(req, res){
+  res.send('create profile');
+};
+
+exports.show = function(req, res){
+  res.send('show profile');
+};
+
+exports.edit = function(req, res){
+  res.send('edit profile');
+};
+
+exports.update = function(req, res){
+  res.send('update profile');
+};
+
+exports.destroy = function(req, res){
+  res.send('destroy profile');
+};

--- a/test/resource.test.js
+++ b/test/resource.test.js
@@ -42,6 +42,41 @@ module.exports = {
       { body: 'destroy forum 5' });
   },
 
+  'test app.singular_resource()': function(){
+    var app = express.createServer();
+
+    var ret = app.singular_resource('profile', require('./fixtures/profile'));
+    assert.ok(ret instanceof Resource);
+
+    assert.response(app,
+      { url: '/profiles' },
+      { status: 404 });
+
+    assert.response(app,
+      { url: '/profile/new' },
+      { body: 'new profile' });
+
+    assert.response(app,
+      { url: '/profile', method: 'POST' },
+      { body: 'create profile' });
+
+    assert.response(app,
+      { url: '/profile' },
+      { body: 'show profile' });
+
+    assert.response(app,
+      { url: '/profile/edit' },
+      { body: 'edit profile' });
+
+    assert.response(app,
+      { url: '/profile', method: 'PUT' },
+      { body: 'update profile' });
+
+    assert.response(app,
+      { url: '/profile', method: 'DELETE' },
+      { body: 'destroy profile' });
+  },
+
   'test top-level app.resource()': function(){
     var app = express.createServer();
 

--- a/test/resource.test.js
+++ b/test/resource.test.js
@@ -42,41 +42,6 @@ module.exports = {
       { body: 'destroy forum 5' });
   },
 
-  'test app.singular_resource()': function(){
-    var app = express.createServer();
-
-    var ret = app.singular_resource('profile', require('./fixtures/profile'));
-    assert.ok(ret instanceof Resource);
-
-    assert.response(app,
-      { url: '/profiles' },
-      { status: 404 });
-
-    assert.response(app,
-      { url: '/profile/new' },
-      { body: 'new profile' });
-
-    assert.response(app,
-      { url: '/profile', method: 'POST' },
-      { body: 'create profile' });
-
-    assert.response(app,
-      { url: '/profile' },
-      { body: 'show profile' });
-
-    assert.response(app,
-      { url: '/profile/edit' },
-      { body: 'edit profile' });
-
-    assert.response(app,
-      { url: '/profile', method: 'PUT' },
-      { body: 'update profile' });
-
-    assert.response(app,
-      { url: '/profile', method: 'DELETE' },
-      { body: 'destroy profile' });
-  },
-
   'test top-level app.resource()': function(){
     var app = express.createServer();
 

--- a/test/singular.test.js
+++ b/test/singular.test.js
@@ -1,0 +1,76 @@
+
+/**
+ * Module dependencies.
+ */
+var assert = require('assert')
+  , express = require('express')
+  , Resource = require('../');
+
+module.exports = {
+  'test app.singular_resource()': function(){
+    var app = express.createServer();
+
+    var ret = app.singular_resource('profile', require('./fixtures/profile'));
+    assert.ok(ret instanceof Resource);
+
+    assert.response(app,
+      { url: '/profiles' },
+      { status: 404 });
+
+    assert.response(app,
+      { url: '/profile/new' },
+      { body: 'new profile' });
+
+    assert.response(app,
+      { url: '/profile', method: 'POST' },
+      { body: 'create profile' });
+
+    assert.response(app,
+      { url: '/profile' },
+      { body: 'show profile' });
+
+    assert.response(app,
+      { url: '/profile/edit' },
+      { body: 'edit profile' });
+
+    assert.response(app,
+      { url: '/profile', method: 'PUT' },
+      { body: 'update profile' });
+
+    assert.response(app,
+      { url: '/profile', method: 'DELETE' },
+      { body: 'destroy profile' });
+  },
+  
+  'test app.singular_resource() for top level': function(){
+    var app = express.createServer();
+
+    var ret = app.singular_resource(require('./fixtures/profile'));
+    assert.ok(ret instanceof Resource);
+
+    assert.response(app,
+      { url: '/new' },
+      { body: 'new profile' });
+
+    assert.response(app,
+      { url: '/', method: 'POST' },
+      { body: 'create profile' });
+
+    assert.response(app,
+      { url: '/' },
+      { body: 'show profile' });
+
+    assert.response(app,
+      { url: '/edit' },
+      { body: 'edit profile' });
+
+    assert.response(app,
+      { url: '/', method: 'PUT' },
+      { body: 'update profile' });
+
+    assert.response(app,
+      { url: '/', method: 'DELETE' },
+      { body: 'destroy profile' });
+  }
+  
+};


### PR DESCRIPTION
I've added a couple more features based on Rails resources: singular resources, where there isn't an id, and member and collection for adding extra non-standard routes.

If I had the choice, I would have used resource/resources instead of singular_resource/resource, but I didn't want to break backward compatibility unilaterally.
