### PR TITLE
A lazy way of doing singular resources

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+*.tmproj
+.DS_Store

--- a/index.js
+++ b/index.js
@@ -29,6 +29,7 @@ var Resource = module.exports = function Resource(name, actions, app) {
   this.app = app;
   this.routes = {};
   actions = actions || {};
+	if (name && lingo.en.isSingular(name)) actions.id = (actions.id || '');
   this.format = actions.format;
   this.id = actions.id == null? this.defaultId: actions.id;
   this.param = this.id == ''? '': ':' + this.id;

--- a/index.js
+++ b/index.js
@@ -30,8 +30,8 @@ var Resource = module.exports = function Resource(name, actions, app) {
   this.routes = {};
   actions = actions || {};
   this.format = actions.format;
-  this.id = actions.id || this.defaultId;
-  this.param = ':' + this.id;
+  this.id = actions.id == null? this.defaultId: actions.id;
+  this.param = this.id == ''? '': ':' + this.id;
 
   // default actions
   for (var key in actions) {

--- a/test/fixtures/profile.js
+++ b/test/fixtures/profile.js
@@ -23,5 +23,5 @@ exports.destroy = function(req, res){
   res.send('destroy profile');
 };
 
-exports.id = '';
+// exports.id = '';
 

--- a/test/fixtures/profile.js
+++ b/test/fixtures/profile.js
@@ -1,0 +1,27 @@
+
+exports.new = function(req, res){
+  res.send('new profile');
+};
+
+exports.create = function(req, res){
+  res.send('create profile');
+};
+
+exports.show = function(req, res){
+  res.send('show profile');
+};
+
+exports.edit = function(req, res){
+  res.send('edit profile');
+};
+
+exports.update = function(req, res){
+  res.send('update profile');
+};
+
+exports.destroy = function(req, res){
+  res.send('destroy profile');
+};
+
+exports.id = '';
+

--- a/test/resource.test.js
+++ b/test/resource.test.js
@@ -199,10 +199,10 @@ module.exports = {
     }};
 
     actions.load = Forum.get;
-    var forum = app.resource('forum', actions);
+    var forum = app.resource('forums', actions);
 
     assert.response(app,
-      { url: '/forum/12' },
+      { url: '/forums/12' },
       { body: 'Ferrets' });
   },
   
@@ -215,13 +215,13 @@ module.exports = {
       res.end(req.forum.title + ': ' + req.thread.title);
     }};
 
-    var forum = app.resource('forum', { load: Forum.get });
-    var threads = app.resource('thread', actions, { load: Thread.get });
+    var forum = app.resource('forums', { load: Forum.get });
+    var threads = app.resource('threads', actions, { load: Thread.get });
 
     forum.add(threads);
 
     assert.response(app,
-      { url: '/forum/12/thread/1' },
+      { url: '/forums/12/threads/1' },
       { body: 'Ferrets: Tobi rules' });
   },
   
@@ -233,11 +233,11 @@ module.exports = {
       res.end(req.forum.title);
     }};
 
-    var forum = app.resource('forum', actions);
+    var forum = app.resource('forums', actions);
     forum.load(Forum.get);
 
     assert.response(app,
-      { url: '/forum/12' },
+      { url: '/forums/12' },
       { body: 'Ferrets' });
   },
   

--- a/test/singular.test.js
+++ b/test/singular.test.js
@@ -1,0 +1,76 @@
+
+/**
+ * Module dependencies.
+ */
+var assert = require('assert')
+  , express = require('express')
+  , Resource = require('../');
+
+module.exports = {
+  'test app.singular_resource()': function(){
+    var app = express.createServer();
+
+    var ret = app.resource('profile', require('./fixtures/profile'));
+    assert.ok(ret instanceof Resource);
+
+    assert.response(app,
+      { url: '/profiles' },
+      { status: 404 });
+
+    assert.response(app,
+      { url: '/profile/new' },
+      { body: 'new profile' });
+
+    assert.response(app,
+      { url: '/profile', method: 'POST' },
+      { body: 'create profile' });
+
+    assert.response(app,
+      { url: '/profile' },
+      { body: 'show profile' });
+
+    assert.response(app,
+      { url: '/profile/edit' },
+      { body: 'edit profile' });
+
+    assert.response(app,
+      { url: '/profile', method: 'PUT' },
+      { body: 'update profile' });
+
+    assert.response(app,
+      { url: '/profile', method: 'DELETE' },
+      { body: 'destroy profile' });
+  },
+  
+  'test app.singular_resource() for top level': function(){
+    var app = express.createServer();
+
+    var ret = app.resource(require('./fixtures/profile'));
+    assert.ok(ret instanceof Resource);
+
+    assert.response(app,
+      { url: '/new' },
+      { body: 'new profile' });
+
+    assert.response(app,
+      { url: '/', method: 'POST' },
+      { body: 'create profile' });
+
+    assert.response(app,
+      { url: '/' },
+      { body: 'show profile' });
+
+    assert.response(app,
+      { url: '/edit' },
+      { body: 'edit profile' });
+
+    assert.response(app,
+      { url: '/', method: 'PUT' },
+      { body: 'update profile' });
+
+    assert.response(app,
+      { url: '/', method: 'DELETE' },
+      { body: 'destroy profile' });
+  }
+  
+};

--- a/test/trace_routes.js
+++ b/test/trace_routes.js
@@ -4,7 +4,7 @@ var assert = require('assert')
 
 var app = express.createServer();
 
-var ret = app.resource('forums', require('./fixtures/forum'));
+var ret = app.resource('profile', require('./fixtures/profile'));
 
 
 Resource.prototype.list_routes = function() {

--- a/test/trace_routes.js
+++ b/test/trace_routes.js
@@ -1,0 +1,31 @@
+var assert = require('assert')
+  , express = require('express')
+  , Resource = require('../');
+
+var app = express.createServer();
+
+var ret = app.resource('forums', require('./fixtures/forum'));
+
+
+Resource.prototype.list_routes = function() {
+	var rs = '';
+	for (var method in this.routes) {
+		rs += method + '>>\n';
+		
+		var routes = this.routes[method];
+		for (var key in routes) {
+			var r = routes[key];
+			rs += r.method + ': ' + r.path + '\n';
+		}
+	}
+	return rs;
+};
+
+console.log(ret.list_routes());
+
+
+module.exports = {
+	'dummy': function() {
+		assert.equal(1, 1);
+	}
+}


### PR DESCRIPTION
I'm not 100% sure this works in all cases, but exporting id as the empty string from a resource with only the singular actions, plus a bit of special-casing on that, and it seems to fall out.

Please take a look when you have a moment.
