### PR TITLE
Quick update to the example using singular resource names for the id 

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -1,4 +1,3 @@
-
 # Express Resource
 
   express-resource provides resourceful routing to express.
@@ -26,19 +25,19 @@ npm:
     };
 
     exports.show = function(req, res){
-      res.send('show forum ' + req.params.id);
+      res.send('show forum ' + req.params.forum);
     };
 
     exports.edit = function(req, res){
-      res.send('edit forum ' + req.params.id);
+      res.send('edit forum ' + req.params.forum);
     };
 
     exports.update = function(req, res){
-      res.send('update forum ' + req.params.id);
+      res.send('update forum ' + req.params.forum;
     };
 
     exports.destroy = function(req, res){
-      res.send('destroy forum ' + req.params.id);
+      res.send('destroy forum ' + req.params.forum);
     };
 
 The `app.resource()` method returns a new `Resource` object, which can be used to further map pathnames, nest resources, and more.


### PR DESCRIPTION
In 0.2.0 I'm not getting a req.params.id but req.params.account when called like

app.resource 'accounts', require('./lib/controllers/accounts_controller')
