### PR TITLE
Allow all request methods to specify format

### DIFF
--- a/index.js
+++ b/index.js
@@ -107,8 +107,7 @@ Resource.prototype.map = function(method, path, fn){
   // setup route pathname
   var route = this.base + (this.name || '');
   if (this.name && path) route += '/';
-  route += path;
-  if ('get' == method) route += '.:format?';
+  route += path + '.:format?';
 
   // register the route so we may later remove it
   (this.routes[method] = this.routes[method] || {})[route] = {


### PR DESCRIPTION
This changes allows ALL request methods to specify format.

From what I gather, besides 'GET' the only other methods supported by this code is 'PUT', 'POST' and 'DELETE' - the methods supported appears to be only defined by the mapping routine 'mapDefaultAction'.

The format specifier is useful to formulate the type and format of the reply to the request.
It does not influence the interpretation of the incoming body content, it does not change that behaviour.
