### PR TITLE
Bugfix: no route order was specified, so /name/:id was taking precedence over /name/new

### DIFF
--- a/index.js
+++ b/index.js
@@ -13,8 +13,17 @@
 var express = require('express')
   , join = require('path').join
   , lingo = require('lingo')
-  , en = lingo.en;
-
+  , en = lingo.en
+  , orderedActions = [
+    'index'   //  GET  /
+    ,'new'    //  GET  /new
+    ,'create' //  POST /
+    ,'show'   //  GET  /:id
+    ,'edit'   //  GET  /edit/:id
+    ,'update' //  PUT  /:id
+    ,'destroy'//  DEL  /:id
+  ];
+  
 /**
  * Initialize a new `Resource` with the given `name` and `actions`.
  *
@@ -36,8 +45,10 @@ var Resource = module.exports = function Resource(name, actions, app) {
   this.param = ':' + this.id;
 
   // default actions
-  for (var key in actions) {
-    this.mapDefaultAction(key, actions[key]);
+  for(var i=0, key; i < orderedActions.length; i++) {
+    key = orderedActions[i];
+    if(actions[key])
+      this.mapDefaultAction(key, actions[key]);
   }
 
   // auto-loader


### PR DESCRIPTION
When defining the routes, the order depended on the order of keys in an object.

Sometimes this meant that the `/resource_name/:id` route was ahead of `/resource_name/new` which ensured that when visiting `/resource_name/new` the request would get mapped to the "show" action with an :id param of 'new'.

I simply defined the order of routes.
