### PR TITLE
Handle dots in resource ids correctly

### DIFF
--- a/index.js
+++ b/index.js
@@ -116,7 +116,7 @@ Resource.prototype.map = function(method, path, fn){
   var route = this.base + (this.name || '');
   if (this.name && path) route += '/';
   route += path;
-  route += '.:format?';
+  route += '.:format([^\/\.]+)?';
 
   // register the route so we may later remove it
   (this.routes[method] = this.routes[method] || {})[route] = {

--- a/test/resource.content-negotiation.test.js
+++ b/test/resource.content-negotiation.test.js
@@ -154,5 +154,28 @@ module.exports = {
     assert.response(app,
       { url: '/users/1/pets.json' },
       { body: '["tobi","jane","loki"]' });
+  },
+  
+  'test ids with dots': function(){
+    var app = express.createServer();
+    app.resource('tests', {show: {
+      json: function(req, res){
+        res.send(req.params.test);
+      }, default: function(req, res){
+        res.send(406);
+      }}}, { format: 'json' });
+    assert.response(app,
+      { url: '/tests/foo' },
+      { body: 'foo'});
+
+    assert.response(app,
+      { url: '/tests/foo.json' },
+      { body: 'foo' });
+    assert.response(app,
+      { url: '/tests/foo.bar.json' },
+      { body: 'foo.bar' });
+    assert.response(app,
+      { url: '/tests/foo.bar' },
+      { status: 406 });
   }
 };


### PR DESCRIPTION
Previously a GET /resource/foo.bar.json parsed this into id=foo and format=bar.json
This is fixed now and results in id=foo.bar and format=json
