### PR TITLE
req.format should be respected if set elsewere

### DIFF
--- a/index.js
+++ b/index.js
@@ -128,7 +128,7 @@ Resource.prototype.map = function(method, path, fn){
 
   // apply the route
   this.app[method](route, function(req, res, next){
-    req.format = req.params.format || self.format;
+    req.format = req.params.format || req.format || self.format;
     if (req.format) res.contentType(req.format);
     if ('object' == typeof fn) {
       if (req.format && fn[req.format]) {


### PR DESCRIPTION
I have made a small middleware that sets the req.format depending on the accept header.

```
app.all('/myresource/*', function(req, res, next){
    if(req.headers.accept){
        if(req.headers.accept == 'application/json') req.format='json';
    }
    next();
});
```

But I found out that req.format was overwritten in the _map_ function.
This change keeps the req.format unless _req.params.format_ format is set which i think should overrule them.

This gives that you can use whatever you set in middleware as a suggestion for format unless it's specifically given on the url.
