### PR TITLE
custom mapping with strings (includes middleware commits)

### DIFF
--- a/index.js
+++ b/index.js
@@ -41,7 +41,7 @@ var Resource = module.exports = function Resource(name, actions, app) {
   this.name = name;
   this.app = app;
   this.routes = {};
-  actions = actions || {};
+  this.actions = actions = actions || {};
   this.base = actions.base || '/';
   if ('/' != this.base[this.base.length - 1]) this.base += '/';
   this.format = actions.format;
@@ -122,6 +122,7 @@ Resource.prototype.map = function(method, path, fn){
   if (method instanceof Resource) return this.add(method);
   if ('function' == typeof path) fn = path, path = '';
   if ('object' == typeof path) fn = path, path = '';
+  if ('string' === typeof fn) fn = this.actions[fn];
   if ('/' == path[0]) path = path.substr(1);
   else path = path ? this.param + '/' + path : this.param;
   method = method.toLowerCase();

--- a/index.js
+++ b/index.js
@@ -140,22 +140,29 @@ Resource.prototype.map = function(method, path, fn){
     , fn: fn
   };
 
-  // apply the route
-  this.app[method](route, function(req, res, next){
-    req.format = req.params.format || req.format || self.format;
-    if (req.format) res.contentType(req.format);
-    if ('object' == typeof fn) {
-      if (req.format && fn[req.format]) {
-        fn[req.format](req, res, next);
-      } else if (fn.default) {
-        fn.default(req, res, next);
+  // apply Array of middleware
+  if (fn instanceof Array) {
+    // TODO: Make arrays of middleware also work with formats
+    this.app[method](route, fn);
+  }
+  else {
+    // apply the route
+    this.app[method](route, function(req, res, next){
+      req.format = req.params.format || req.format || self.format;
+      if (req.format) res.contentType(req.format);
+      if ('object' == typeof fn) {
+        if (req.format && fn[req.format]) {
+          fn[req.format](req, res, next);
+        } else if (fn.default) {
+          fn.default(req, res, next);
+        } else {
+          res.send(406);
+        }
       } else {
-        res.send(406);
+        fn(req, res, next);
       }
-    } else {
-      fn(req, res, next);
-    }
-  });
+    });  
+  }
 
   return this;
 };

--- a/test/fixtures/cat.js
+++ b/test/fixtures/cat.js
@@ -14,6 +14,19 @@ exports.filter = function(req, res, next) {
 
 exports.edit = [
   exports.filter,
-  function(req, res, next) {
+  function(req, res) {
     res.send('usertype: ' + req.usertype);
-  }];
+  }
+];
+
+exports.show = [
+  exports.filter,
+  function(req, res) {
+    if ('json' === req.format) {
+      res.send(JSON.stringify({usertype: req.usertype}));
+    }
+    else {
+      res.send('usertype: ' + req.usertype);
+    }
+  }
+];

--- a/test/fixtures/cat.js
+++ b/test/fixtures/cat.js
@@ -6,3 +6,14 @@ exports.index = function(req, res){
 exports.new = function(req, res){
   res.send('new cat');
 };
+
+exports.filter = function(req, res, next) {
+  req.usertype = 'cat owner';
+  next();
+};
+
+exports.edit = [
+  exports.filter,
+  function(req, res, next) {
+    res.send('usertype: ' + req.usertype);
+  }];

--- a/test/fixtures/forum.middleware.js
+++ b/test/fixtures/forum.middleware.js
@@ -1,0 +1,43 @@
+
+
+function middleware(req, res, next) {
+  req.user = 'middleware user';
+  next();
+}
+
+exports.index = function(req, res){
+  res.send('forum index');
+};
+
+exports.new = function(req, res){
+  res.send('new forum');
+};
+
+exports.create = function(req, res){
+  res.send('create forum');
+};
+
+exports.show = [
+  middleware,
+  function(req, res){
+    res.send('show forum ' + req.params.forum);
+  }
+];
+
+exports.edit = function(req, res){
+  res.send('edit forum ' + req.params.forum);
+};
+
+exports.update = function(req, res){
+  res.send('update forum ' + req.params.forum);
+};
+
+exports.destroy = function(req, res){
+  res.send('destroy forum ' + req.params.forum);
+};
+
+exports.load = function(id, fn){
+  process.nextTick(function(){
+    fn(null, { title: 'Ferrets' });
+  });
+};

--- a/test/fixtures/thread.middleware.js
+++ b/test/fixtures/thread.middleware.js
@@ -1,0 +1,53 @@
+
+
+function middleware(req, res, next) {
+  req.role = 'thread owner';
+  next();
+}
+
+exports.index = function(req, res){
+  res.send('thread index of forum ' + req.params.forum);
+};
+
+exports.new = function(req, res){
+  res.send('new thread');
+};
+
+exports.create = function(req, res){
+  res.send('create thread');
+};
+
+exports.show = [
+  middleware,
+  function(req, res){
+    if (req.format === 'json') {
+      res.send(JSON.stringify({
+        thread: req.params.thread,
+        forum: req.params.forum,
+        user: req.user,           // Should not be populated because middleware should only run for the final route
+        role: req.role
+      }));
+    }
+    else {
+      res.send('show thread ' + req.params.thread + ' of forum ' + req.params.forum + ' for ' + req.user + ', ' + req.role);
+    }
+  }
+];
+
+exports.edit = function(req, res){
+  res.send('edit thread ' + req.params.thread + ' of forum ' + req.params.forum);
+};
+
+exports.update = function(req, res){
+  res.send('update thread ' + req.params.thread + ' of forum ' + req.params.forum);
+};
+
+exports.destroy = function(req, res){
+  res.send('destroy thread ' + req.params.thread + ' of forum ' + req.params.forum);
+};
+
+exports.load = function(id, fn){
+  process.nextTick(function(){
+    fn(null, { title: 'Tobi rules' });
+  });
+};

--- a/test/resource.content-negotiation.test.js
+++ b/test/resource.content-negotiation.test.js
@@ -48,101 +48,7 @@ module.exports = {
       { url: '/pets/0.json', method: 'DELETE' },
       { body: '{"message":"pet removed"}' });
   },
-  
-  'test content-negotiation via format method': function(){
-    var app = express.createServer();
-  
-    app.resource('pets', require('./fixtures/pets.format-methods'));
-  
-    assert.response(app,
-      { url: '/pets.xml' },
-      { body: '<pets><pet>tobi</pet><pet>jane</pet><pet>loki</pet></pets>'
-      , headers: { 'Content-Type': 'application/xml' }});
-  
-    assert.response(app,
-      { url: '/pets.json' },
-      { body: '["tobi","jane","loki"]'
-      , headers: { 'Content-Type': 'application/json; charset=utf-8' }});
-  
-    assert.response(app,
-      { url: '/pets' },
-      { body: 'Unsupported format', status: 406 });
-  },
-  
-  'test content-negotiation via format method without default': function(){
-    var app = express.createServer();
-  
-    app.resource('pets', require('./fixtures/pets.format-methods-without-default'));
-  
-    assert.response(app,
-      { url: '/pets.xml' },
-      { body: '<pets><pet>tobi</pet><pet>jane</pet><pet>loki</pet></pets>'
-      , headers: { 'Content-Type': 'application/xml' }});
-  
-    assert.response(app,
-      { url: '/pets.json' },
-      { body: '["tobi","jane","loki"]'
-      , headers: { 'Content-Type': 'application/json; charset=utf-8' }});
-  
-    assert.response(app,
-      { url: '/pets' },
-      { body: 'Not Acceptable', status: 406 });
-  },
-  
-  'test content-negotiation via map()': function(){
-    var app = express.createServer();
-  
-    app.use(express.bodyParser());
-  
-    var pets = app.resource('pets')
-      , toys = app.resource('toys')
-      , toysDB = ["balls", "platforms", "tunnels"];
-
-    toys.get('/types', function(req, res){
-      res.send(toysDB);
-    });  
-
-    toys.get('/', {
-      json: function(req, res){
-        res.send(toysDB);
-      }
-    });
-    
-    toys.get({
-      json: function(req, res){
-        res.send('"' + toysDB[req.params.toy] + '"');
-      }
-    });
-  
-    pets.add(toys);
-  
-    pets.get('/', {
-      json: function(req, res){
-        res.send({ name: 'tobi' });
-      }
-    });
-  
-    assert.response(app,
-      { url: '/pets/0/toys/types' },
-      { body: '["balls","platforms","tunnels"]' });
-
-    assert.response(app,
-      { url: '/pets/0/toys/2.json' },
-      { body: '"tunnels"' });
-
-    assert.response(app,
-      { url: '/pets/0/toys.json' },
-      { body: '["balls","platforms","tunnels"]' });
       
-    assert.response(app,
-      { url: '/pets.json' },
-      { body: '{"name":"tobi"}' });
-      
-    assert.response(app,
-      { url: '/pets' },
-      { status: 406 });
-  },
-  
   'test nested content-negotiation': function(){
     var app = express.createServer()
       , pets = ['tobi', 'jane', 'loki'];
@@ -154,5 +60,20 @@ module.exports = {
     assert.response(app,
       { url: '/users/1/pets.json' },
       { body: '["tobi","jane","loki"]' });
+  },
+
+  'test content-negotiation with middleware': function() {
+    var app = express.createServer();
+
+    var cat = app.resource('api/cat', require('./fixtures/cat'));
+
+    assert.response(app,
+      { url: '/api/cat/1' },
+      { body: 'usertype: cat owner' });
+
+    assert.response(app,
+      { url: '/api/cat/1.json' },
+      { body: '{"usertype":"cat owner"}'
+        , headers: { 'Content-Type': 'application/json' } });
   }
 };

--- a/test/resource.test.js
+++ b/test/resource.test.js
@@ -169,7 +169,7 @@ module.exports = {
     var forum = app.resource('forums', require('./fixtures/forum'));
     var thread = app.resource('threads', require('./fixtures/thread'));
 
-    var ret = user.add(forum);
+    var ret = user.map(forum);
     ret.should.equal(user);
     
     var ret = forum.add(thread);
@@ -301,7 +301,10 @@ module.exports = {
       },
       logout: function(req, res){
         res.end('logout');
-      }
+      }/*,
+      show: function(req, res) {
+        res.end('login and logout must be registered ahead of show to work');
+      }*/
     };
     
     var users = app.resource('users', actions, { load: load });
@@ -362,5 +365,33 @@ module.exports = {
       { url: '/forums/1/threads/50.json' },
       { body: '{"thread":"50","forum":"1","role":"thread owner"}'
         , headers: { 'Content-Type': 'application/json' } });
+  },
+
+  'test mapping custom actions with strings': function() {
+    var app = express.createServer();
+    
+    var actions = {
+      login: function(req, res){
+        res.end('login');
+      },
+      logout: function(req, res){
+        res.end('logout');
+      }/*,
+      show: function(req, res) {
+        res.end('login and logout must be registered ahead of show to work');
+      }*/
+    };
+    
+    app.resource('users', actions)
+      .map('all', '/login', 'login')
+      .map('all', '/logout', 'logout');
+    
+    assert.response(app,
+      { url: '/users/login' },
+      { body: 'login' });
+
+    assert.response(app,
+      { url: '/users/logout' },
+      { body: 'logout' });
   }
 };

--- a/test/resource.test.js
+++ b/test/resource.test.js
@@ -328,5 +328,14 @@ module.exports = {
     assert.response(app,
       { url: '/api/cat/new' },
       { body: 'new cat' });
+  },
+
+  'test middleware by array': function() {
+    var app = express.createServer();
+    var cat = app.resource('api/cat', require('./fixtures/cat'));
+
+    assert.response(app,
+      { url: '/api/cat/1/edit' },
+      { body: 'usertype: cat owner' });
   }
 };

--- a/test/resource.test.js
+++ b/test/resource.test.js
@@ -337,5 +337,30 @@ module.exports = {
     assert.response(app,
       { url: '/api/cat/1/edit' },
       { body: 'usertype: cat owner' });
+  },
+
+  'test middleware by array with shallow nesting and format': function(){
+    var app = express.createServer();
+
+    var forum = app.resource('forums', require('./fixtures/forum.middleware'));
+    var thread = app.resource('threads', require('./fixtures/thread.middleware'));
+    forum.map(thread);
+
+    assert.response(app,
+      { url: '/forums' },
+      { body: 'forum index' });
+
+    assert.response(app,
+      { url: '/forums/12' },
+      { body: 'show forum 12' });
+
+    assert.response(app,
+      { url: '/forums/12/threads' },
+      { body: 'thread index of forum 12' });
+    
+    assert.response(app,
+      { url: '/forums/1/threads/50.json' },
+      { body: '{"thread":"50","forum":"1","role":"thread owner"}'
+        , headers: { 'Content-Type': 'application/json' } });
   }
 };


### PR DESCRIPTION
A 1-line addition (+tests) for:

``` javascript
  server.resource('sessions', controllers.session)
    .map('all', '/login', 'new')
    .map('all', '/logout', 'destroy');
```

**Is this a bug?**
While testing this I noticed that if any resource has a 'show' method custom routes won't work on it, since 'show' will be defined before the custom routes and so the custom mapping will be interpreted as an ID. The fix sounds simple - mount custom routes ahead of default routes - but since I don't really know the inner workings of express I don't want to jump into that right now.
