### PR TITLE
Add correct homepage to project

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,7 @@
 {   "name": "express-resource"
   , "description": "Resourceful routing for express"
   , "version": "0.2.4"
+  , "homepage": "https://github.com/visionmedia/express-resource"
   , "author": "TJ Holowaychuk <tj@vision-media.ca>"
   , "contributors": [
     { "name": "Daniel Gasienica", "email": "daniel@gasienica.ch" }


### PR DESCRIPTION
Currently redirects to http://search.npmjs.org/#/express-resource. ew.
