### PR TITLE
Path generation

### DIFF
--- a/index.js
+++ b/index.js
@@ -61,7 +61,9 @@ function Resource(name, actions, app) {
   // default actions
   for (var i = 0, key; i < orderedActions.length; ++i) {
     key = orderedActions[i];
-    if (actions[key]) this.mapDefaultAction(key, actions[key]);
+    var handler = actions[key];
+    if (typeof handler === 'function') handler = handler.bind(actions);
+    if (handler) this.mapDefaultAction(key, handler);
   }
 
   // auto-loader

--- a/index.js
+++ b/index.js
@@ -246,6 +246,47 @@ Resource.prototype.mapDefaultAction = function(key, fn){
 };
 
 /**
+ * Get edit path for resource. Ex '/users/42/edit'.
+ *
+ * @param {String} id of resource to edit
+ * @return {String} Url of resource "root"
+ */
+
+Resource.prototype.editPath = function(id) {
+  return '/' + this.name + '/' + id + '/edit';
+}
+
+/**
+ * Get path for creating a new resource. Ex '/users/new'.
+ *
+ * @return {String} Url of path to form for creating new resources
+ */
+
+Resource.prototype.newPath = function() {
+  return '/' + this.name + '/new';
+}
+
+/**
+ * Get "collection" url for resource. Ex '/users'.
+ *
+ * @return {String} Url of resource "root"
+ */
+
+Resource.prototype.collectionPath = function() {
+  return '/' + this.name;
+}
+
+/**
+ * Get "collection" url for resource. Ex '/users/42'.
+ *
+ * @return {String} Url of record resource including id
+ */
+
+Resource.prototype.recordPath = function(id) {
+  return '/' + this.name + '/' + id;
+}
+
+/**
  * Setup http verb methods.
  */
 

--- a/index.js
+++ b/index.js
@@ -189,6 +189,8 @@ Resource.prototype.add = function(resource){
     + (this.name ? this.name + '/': '')
     + this.param + '/';
 
+  resource.parent = this;
+
   // re-define previous actions
   for (var method in resource.routes) {
     routes = resource.routes[method];
@@ -248,42 +250,50 @@ Resource.prototype.mapDefaultAction = function(key, fn){
 /**
  * Get edit path for resource. Ex '/users/42/edit'.
  *
- * @param {String} id of resource to edit
+ * @param {String} ids Array of ids for parents if resource is nested
  * @return {String} Url of resource "root"
  */
 
-Resource.prototype.editPath = function(id) {
-  return '/' + this.name + '/' + id + '/edit';
+Resource.prototype.editPath = function(ids) {
+  var parentPath = this.parent ? this.parent.recordPath(ids.slice(0, -1)) : '';
+  return parentPath + '/' + this.name + '/' + ids[ids.length - 1] + '/edit';
 }
 
 /**
  * Get path for creating a new resource. Ex '/users/new'.
  *
+ * @param {Array[String]} ids Array of ids for parents if resource is nested
  * @return {String} Url of path to form for creating new resources
  */
 
-Resource.prototype.newPath = function() {
-  return '/' + this.name + '/new';
+Resource.prototype.newPath = function(ids) {
+  debugger;
+  var parentPath = this.parent ? this.parent.recordPath(ids) : '';
+  return parentPath + '/' + this.name + '/new';
 }
 
 /**
  * Get "collection" url for resource. Ex '/users'.
  *
+ * @param {Array[String]} ids Array of ids for parents if resource is nested
  * @return {String} Url of resource "root"
  */
 
-Resource.prototype.collectionPath = function() {
-  return '/' + this.name;
+Resource.prototype.collectionPath = function(ids) {
+  var parentPath = this.parent ? this.parent.recordPath(ids) : '';
+  return parentPath + '/' + this.name;
 }
 
 /**
  * Get "collection" url for resource. Ex '/users/42'.
  *
+ * @param {Array[String]} ids Array of ids for parents if resource is nested
  * @return {String} Url of record resource including id
  */
 
-Resource.prototype.recordPath = function(id) {
-  return '/' + this.name + '/' + id;
+Resource.prototype.recordPath = function(ids) {
+  var parentPath = this.parent ? this.parent.recordPath(ids.slice(0, -1)) : '';
+  return parentPath + '/' + this.name + '/' + ids[ids.length - 1];
 }
 
 /**

--- a/index.js
+++ b/index.js
@@ -254,9 +254,11 @@ Resource.prototype.mapDefaultAction = function(key, fn){
  * @return {String} Url of resource "root"
  */
 
-Resource.prototype.editPath = function(ids) {
-  var parentPath = this.parent ? this.parent.recordPath(ids.slice(0, -1)) : '';
-  return parentPath + '/' + this.name + '/' + ids[ids.length - 1] + '/edit';
+Resource.prototype.editPath = function() {
+  var ids = Array.prototype.slice.call(arguments);
+  var id = ids.pop();
+  var parentPath = this.parent ? this.parent.recordPath.apply(this.parent, ids) : '';
+  return parentPath + '/' + this.name + '/' + id + '/edit';
 }
 
 /**
@@ -266,9 +268,9 @@ Resource.prototype.editPath = function(ids) {
  * @return {String} Url of path to form for creating new resources
  */
 
-Resource.prototype.newPath = function(ids) {
-  debugger;
-  var parentPath = this.parent ? this.parent.recordPath(ids) : '';
+Resource.prototype.newPath = function() {
+  var ids = Array.prototype.slice.call(arguments);
+  var parentPath = this.parent ? this.parent.recordPath.apply(this.parent, ids) : '';
   return parentPath + '/' + this.name + '/new';
 }
 
@@ -279,8 +281,9 @@ Resource.prototype.newPath = function(ids) {
  * @return {String} Url of resource "root"
  */
 
-Resource.prototype.collectionPath = function(ids) {
-  var parentPath = this.parent ? this.parent.recordPath(ids) : '';
+Resource.prototype.collectionPath = function() {
+  var ids = Array.prototype.slice.call(arguments);
+  var parentPath = this.parent ? this.parent.recordPath.apply(this.parent, ids) : '';
   return parentPath + '/' + this.name;
 }
 
@@ -291,9 +294,11 @@ Resource.prototype.collectionPath = function(ids) {
  * @return {String} Url of record resource including id
  */
 
-Resource.prototype.recordPath = function(ids) {
-  var parentPath = this.parent ? this.parent.recordPath(ids.slice(0, -1)) : '';
-  return parentPath + '/' + this.name + '/' + ids[ids.length - 1];
+Resource.prototype.recordPath = function() {
+  var ids = Array.prototype.slice.call(arguments);
+  var id = ids.pop();
+  var parentPath = this.parent ? this.parent.recordPath.apply(this.parent, ids) : '';
+  return parentPath + '/' + this.name + '/' + id;
 }
 
 /**

--- a/test/resource.test.js
+++ b/test/resource.test.js
@@ -143,6 +143,28 @@ describe('app.resource()', function(){
      .expect('destroy thread 50 of forum 12', next()) 
    })
   
+   describe('url generation for non-nested resources', function() {
+     it('should return new urls', function() {
+       var app = express();
+       assert.equal(app.resource('users').newPath(), '/users/new');
+     });
+
+     it('should return edit urls', function() {
+       var app = express();
+       assert.equal(app.resource('users').editPath(42), '/users/42/edit');
+     });
+
+     it('should return collection urls', function() {
+       var app = express();
+       assert.equal(app.resource('users').collectionPath(), '/users');
+     });
+
+     it('should return record urls with ids', function() {
+       var app = express();
+       assert.equal(app.resource('users').recordPath(42), '/users/42');
+     });
+   });
+
    describe('"id" option', function(){
      it('should allow overriding the default', function(done){
        var app = express();

--- a/test/resource.test.js
+++ b/test/resource.test.js
@@ -154,7 +154,7 @@ describe('app.resource()', function(){
      });
 
      it('should return edit urls', function() {
-       assert.equal(app.resource('users').editPath(42), '/users/42/edit');
+       assert.equal(app.resource('users').editPath([42]), '/users/42/edit');
      });
 
      it('should return collection urls', function() {
@@ -162,7 +162,35 @@ describe('app.resource()', function(){
      });
 
      it('should return record urls with ids', function() {
-       assert.equal(app.resource('users').recordPath(42), '/users/42');
+       assert.equal(app.resource('users').recordPath([42]), '/users/42');
+     });
+   });
+
+   describe('url generation for nested resources', function() {
+     var app;
+     var dummyController = {show: function(req, res) { res.send('hello world'); }};
+     beforeEach(function() {
+       app = express();
+       var forums = app.resource('forums', dummyController);
+       var threads = app.resource('threads', dummyController);
+       var replies = app.resource('replies', dummyController);
+       forums.add(threads);
+       threads.add(replies);
+     });
+     it('should return new urls', function() {
+       assert.equal(app.resource('replies').newPath([1, 2]), '/forums/1/threads/2/replies/new');
+     });
+
+     it('should return edit urls', function() {
+       assert.equal(app.resource('replies').editPath([1, 2, 3]), '/forums/1/threads/2/replies/3/edit');
+     });
+
+     it('should return collection urls', function() {
+       assert.equal(app.resource('replies').collectionPath([1, 2]), '/forums/1/threads/2/replies');
+     });
+
+     it('should return record urls with ids', function() {
+       assert.equal(app.resource('replies').recordPath([1, 2, 3]), '/forums/1/threads/2/replies/3');
      });
    });
 

--- a/test/resource.test.js
+++ b/test/resource.test.js
@@ -144,23 +144,24 @@ describe('app.resource()', function(){
    })
   
    describe('url generation for non-nested resources', function() {
+     var app;
+     beforeEach(function() {
+       app = express();
+       app.resource('users');
+     });
      it('should return new urls', function() {
-       var app = express();
        assert.equal(app.resource('users').newPath(), '/users/new');
      });
 
      it('should return edit urls', function() {
-       var app = express();
        assert.equal(app.resource('users').editPath(42), '/users/42/edit');
      });
 
      it('should return collection urls', function() {
-       var app = express();
        assert.equal(app.resource('users').collectionPath(), '/users');
      });
 
      it('should return record urls with ids', function() {
-       var app = express();
        assert.equal(app.resource('users').recordPath(42), '/users/42');
      });
    });

--- a/test/resource.test.js
+++ b/test/resource.test.js
@@ -1,6 +1,7 @@
 
 var assert = require('assert')
   , express = require('express')
+  , should = require('should')
   , Resource = require('..')
   , request = require('supertest')
   , batch = require('./support/batch');

--- a/test/resource.test.js
+++ b/test/resource.test.js
@@ -154,7 +154,7 @@ describe('app.resource()', function(){
      });
 
      it('should return edit urls', function() {
-       assert.equal(app.resource('users').editPath([42]), '/users/42/edit');
+       assert.equal(app.resource('users').editPath(42), '/users/42/edit');
      });
 
      it('should return collection urls', function() {
@@ -162,7 +162,7 @@ describe('app.resource()', function(){
      });
 
      it('should return record urls with ids', function() {
-       assert.equal(app.resource('users').recordPath([42]), '/users/42');
+       assert.equal(app.resource('users').recordPath(42), '/users/42');
      });
    });
 
@@ -178,19 +178,19 @@ describe('app.resource()', function(){
        threads.add(replies);
      });
      it('should return new urls', function() {
-       assert.equal(app.resource('replies').newPath([1, 2]), '/forums/1/threads/2/replies/new');
+       assert.equal(app.resource('replies').newPath(1, 2), '/forums/1/threads/2/replies/new');
      });
 
      it('should return edit urls', function() {
-       assert.equal(app.resource('replies').editPath([1, 2, 3]), '/forums/1/threads/2/replies/3/edit');
+       assert.equal(app.resource('replies').editPath(1, 2, 3), '/forums/1/threads/2/replies/3/edit');
      });
 
      it('should return collection urls', function() {
-       assert.equal(app.resource('replies').collectionPath([1, 2]), '/forums/1/threads/2/replies');
+       assert.equal(app.resource('replies').collectionPath(1, 2), '/forums/1/threads/2/replies');
      });
 
      it('should return record urls with ids', function() {
-       assert.equal(app.resource('replies').recordPath([1, 2, 3]), '/forums/1/threads/2/replies/3');
+       assert.equal(app.resource('replies').recordPath(1, 2, 3), '/forums/1/threads/2/replies/3');
      });
    });
 

--- a/test/resource.test.js
+++ b/test/resource.test.js
@@ -56,6 +56,21 @@ describe('app.resource()', function(){
     .expect('destroy forum 5', next());
   })
 
+  it('should bind this correctly', function(done) {
+    var app = express();
+    var testController = {
+      'users': 'userA userB',
+      'index': function(req, res) {
+        res.send(this.users);
+      }
+    };
+
+    app.resource('users', testController);
+    request(app)
+      .get('/users')
+      .expect('userA userB', done);
+  });
+
   it('should support root resources', function(done){
      var app = express();
      var next = batch(done);


### PR DESCRIPTION
I noticed that URL generation has been added as an issue like 2 years ago and there's even an orphaned pull request for it.

The pull request seems to be made for an older version so I made a new pull request based on the latest master. Technically this is all about path generation so far, not URL generation, but I keep using them interchangeably even if I try not to.

When calling add I'm adding a reference to the parent resource and then we can recursively create urls by referring to the parent's recordPath.

The test cases show how the methods can be used.
