### PR TITLE
fix warnings from express for deprecated 'del' by changing to delete.

### DIFF
--- a/index.js
+++ b/index.js
@@ -238,7 +238,7 @@ Resource.prototype.mapDefaultAction = function(key, fn){
       this.patch(fn);
       break;
     case 'destroy':
-      this.del(fn);
+      this.delete(fn);
       break;
   }
 };


### PR DESCRIPTION
fixes warning from express 3.6.0:
"express: app.del: Use app.delete instead"
