### PR TITLE
move to app.delete to supress deprecated warning

### DIFF
--- a/index.js
+++ b/index.js
@@ -238,7 +238,7 @@ Resource.prototype.mapDefaultAction = function(key, fn){
       this.patch(fn);
       break;
     case 'destroy':
-      this.del(fn);
+      this.delete(fn);
       break;
   }
 };


### PR DESCRIPTION
Annoyed by the `npm WARN package.json express-resource@1.0.0 No repository field.` and `express deprecated app.del: Use app.delete instead` warnings.
Looks like the former is fixed but not on npm, this pull fixes the latter.
