### PR TITLE
Overcome Express 4 deprecation message

### DIFF
--- a/index.js
+++ b/index.js
@@ -29,7 +29,7 @@ var orderedActions = [
   , 'edit'    //  GET   /edit/:id
   , 'update'  //  PUT   /:id
   , 'patch'   //  PATCH /:id
-  , 'destroy' //  DEL   /:id
+  , 'destroy' //  DELETE   /:id
 ];
 
 /**
@@ -238,7 +238,7 @@ Resource.prototype.mapDefaultAction = function(key, fn){
       this.patch(fn);
       break;
     case 'destroy':
-      this.del(fn);
+      this.delete(fn);
       break;
   }
 };


### PR DESCRIPTION
Express 4 made .del() deprecated and renamed it to .delete().
